### PR TITLE
Moved methods off of IStringLocalizer and into extension methods

### DIFF
--- a/src/Microsoft.Framework.Localization.Abstractions/IStringLocalizerExtensions.cs
+++ b/src/Microsoft.Framework.Localization.Abstractions/IStringLocalizerExtensions.cs
@@ -1,22 +1,19 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved. 
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
-using System.Collections.Generic;
-using System.Globalization;
-
 namespace Microsoft.Framework.Localization
 {
-    /// <summary>
-    /// Represents a service that provides localized strings.
-    /// </summary>
-    public interface IStringLocalizer : IEnumerable<LocalizedString>
+    public static class IStringLocalizerExtensions
     {
         /// <summary>
         /// Gets the string resource with the given name.
         /// </summary>
         /// <param name="name">The name of the string resource.</param>
         /// <returns>The string resource as a <see cref="LocalizedString"/>.</returns>
-        LocalizedString this[string name] { get; }
+        public static LocalizedString GetString(this IStringLocalizer stringLocalizer, string name)
+        {
+            return stringLocalizer[name];
+        }
 
         /// <summary>
         /// Gets the string resource with the given name and formatted with the supplied arguments.
@@ -24,13 +21,9 @@ namespace Microsoft.Framework.Localization
         /// <param name="name">The name of the string resource.</param>
         /// <param name="arguments">The values to format the string with.</param>
         /// <returns>The formatted string resource as a <see cref="LocalizedString"/>.</returns>
-        LocalizedString this[string name, params object[] arguments] { get; }
-        
-        /// <summary>
-        /// Creates a new <see cref="ResourceManagerStringLocalizer"/> for a specific <see cref="CultureInfo"/>.
-        /// </summary>
-        /// <param name="culture">The <see cref="CultureInfo"/> to use.</param>
-        /// <returns>A culture-specific <see cref="IStringLocalizer"/>.</returns>
-        IStringLocalizer WithCulture(CultureInfo culture);
+        public static LocalizedString GetString(this IStringLocalizer stringLocalizer, string name, params object[] arguments)
+        {
+            return stringLocalizer[name, arguments];
+        }
     }
 }

--- a/src/Microsoft.Framework.Localization.Abstractions/StringLocalizerExtensions.cs
+++ b/src/Microsoft.Framework.Localization.Abstractions/StringLocalizerExtensions.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Framework.Localization
 {
-    public static class IStringLocalizerExtensions
+    public static class StringLocalizerExtensions
     {
         /// <summary>
         /// Gets the string resource with the given name.

--- a/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizer.cs
+++ b/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizer.cs
@@ -51,26 +51,26 @@ namespace Microsoft.Framework.Localization
         /// The base name of the embedded resource in the <see cref="Assembly"/> that contains the strings.
         /// </summary>
         protected string ResourceBaseName { get; }
-        
-        /// <inheritdoc />
-        public virtual LocalizedString this[[NotNull] string name] => GetString(name);
 
         /// <inheritdoc />
-        public virtual LocalizedString this[[NotNull] string name, params object[] arguments] => GetString(name, arguments);
-
-        /// <inheritdoc />
-        public virtual LocalizedString GetString([NotNull] string name)
+        public virtual LocalizedString this[[NotNull] string name]
         {
-            var value = GetStringSafely(name, null);
-            return new LocalizedString(name, value ?? name, resourceNotFound: value == null);
+            get
+            {
+                var value = GetStringSafely(name, null);
+                return new LocalizedString(name, value ?? name, resourceNotFound: value == null);
+            }
         }
 
         /// <inheritdoc />
-        public virtual LocalizedString GetString([NotNull] string name, params object[] arguments)
+        public virtual LocalizedString this[[NotNull] string name, params object[] arguments]
         {
-            var format = GetStringSafely(name, null);
-            var value = string.Format(format ?? name, arguments);
-            return new LocalizedString(name, value, resourceNotFound: format == null);
+            get
+            {
+                var format = GetStringSafely(name, null);
+                var value = string.Format(format ?? name, arguments);
+                return new LocalizedString(name, value, resourceNotFound: format == null);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Framework.Localization/ResourceManagerWithCultureStringLocalizer.cs
+++ b/src/Microsoft.Framework.Localization/ResourceManagerWithCultureStringLocalizer.cs
@@ -36,24 +36,24 @@ namespace Microsoft.Framework.Localization
         }
 
         /// <inheritdoc />
-        public override LocalizedString this[[NotNull] string name] => GetString(name);
-
-        /// <inheritdoc />
-        public override LocalizedString this[[NotNull] string name, params object[] arguments] => GetString(name, arguments);
-
-        /// <inheritdoc />
-        public override LocalizedString GetString([NotNull] string name)
+        public override LocalizedString this[[NotNull] string name]
         {
-            var value = GetStringSafely(name, _culture);
-            return new LocalizedString(name, value ?? name);
+            get
+            {
+                var value = GetStringSafely(name, _culture);
+                return new LocalizedString(name, value ?? name);
+            }
         }
 
         /// <inheritdoc />
-        public override LocalizedString GetString([NotNull] string name, params object[] arguments)
+        public override LocalizedString this[[NotNull] string name, params object[] arguments]
         {
-            var format = GetStringSafely(name, _culture);
-            var value = string.Format(_culture, format ?? name, arguments);
-            return new LocalizedString(name, value ?? name, resourceNotFound: format == null);
+            get
+            {
+                var format = GetStringSafely(name, _culture);
+                var value = string.Format(_culture, format ?? name, arguments);
+                return new LocalizedString(name, value ?? name, resourceNotFound: format == null);
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
@Eilon had mentioned he thought having both the indexers and get methods on the `IStringLocalizer` interface was overkill so I've changed the get methods to be extension methods instead.