### PR TITLE
Cache the walking of the CultureInfo tree in ResourceManagerStringLocalizer

### DIFF
--- a/Localization.sln
+++ b/Localization.sln
@@ -24,6 +24,10 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "CultureInfoGenerator", "src
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Globalization.CultureInfoCache", "src\Microsoft.Framework.Globalization.CultureInfoCache\Microsoft.Framework.Globalization.CultureInfoCache.xproj", "{F3988D3A-A4C8-4FD7-BAFE-13E0D0A1659A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{B723DB83-A670-4BCB-95FB-195361331AD2}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Localization.Test", "test\Microsoft.Framework.Localization.Test\Microsoft.Framework.Localization.Test.xproj", "{287AD58D-DF34-4F16-8616-FD78FA1CADF9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,6 +58,10 @@ Global
 		{F3988D3A-A4C8-4FD7-BAFE-13E0D0A1659A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F3988D3A-A4C8-4FD7-BAFE-13E0D0A1659A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3988D3A-A4C8-4FD7-BAFE-13E0D0A1659A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{287AD58D-DF34-4F16-8616-FD78FA1CADF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{287AD58D-DF34-4F16-8616-FD78FA1CADF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{287AD58D-DF34-4F16-8616-FD78FA1CADF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{287AD58D-DF34-4F16-8616-FD78FA1CADF9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,5 +73,6 @@ Global
 		{55D9501F-15B9-4339-A0AB-6082850E5FCE} = {79878809-8D1C-4BD4-BA99-F1F13FF96FD8}
 		{BD22AE1C-6631-4DA6-874D-0DC0F803CEAB} = {FB313677-BAB3-4E49-8CDB-4FA4A9564767}
 		{F3988D3A-A4C8-4FD7-BAFE-13E0D0A1659A} = {FB313677-BAB3-4E49-8CDB-4FA4A9564767}
+		{287AD58D-DF34-4F16-8616-FD78FA1CADF9} = {B723DB83-A670-4BCB-95FB-195361331AD2}
 	EndGlobalSection
 EndGlobal

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/api/v2" />
+    <add key="xunit" value="https://www.myget.org/F/xunit/api/v2" />
     <add key="NuGet" value="https://nuget.org/api/v2/" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.Framework.Localization/Internal/AssemblyWrapper.cs
+++ b/src/Microsoft.Framework.Localization/Internal/AssemblyWrapper.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Reflection;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.Framework.Localization.Internal
+{
+    public class AssemblyWrapper
+    {
+        public AssemblyWrapper([NotNull] Assembly assembly)
+        {
+            Assembly = assembly;
+        }
+
+        public Assembly Assembly { get; }
+
+        public virtual string FullName => Assembly.FullName;
+
+        public virtual Stream GetManifestResourceStream(string name) => Assembly.GetManifestResourceStream(name);
+    }
+}

--- a/src/Microsoft.Framework.Localization/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.Localization/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Framework.Localization.Test")]

--- a/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizer.cs
+++ b/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizer.cs
@@ -149,6 +149,12 @@ namespace Microsoft.Framework.Localization
             }
         }
 
+        // Internal to allow testing
+        internal static void ClearResourceNamesCache()
+        {
+            _resourceNamesCache.Clear();
+        }
+
         private IEnumerable<string> GetResourceNamesFromCultureHierarchy(CultureInfo startingCulture)
         {
             var currentCulture = startingCulture;

--- a/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizer.cs
+++ b/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizer.cs
@@ -21,10 +21,9 @@ namespace Microsoft.Framework.Localization
         private readonly ConcurrentDictionary<string, object> _missingManifestCache =
             new ConcurrentDictionary<string, object>();
 
-        private readonly ConcurrentDictionary<string, IList<string>> _resourceNamesCache =
+        private static readonly ConcurrentDictionary<string, IList<string>> _resourceNamesCache =
             new ConcurrentDictionary<string, IList<string>>();
-
-
+        
         /// <summary>
         /// Creates a new <see cref="ResourceManagerStringLocalizer"/>.
         /// </summary>
@@ -188,7 +187,9 @@ namespace Microsoft.Framework.Localization
             }
             resourceStreamName += ".resources";
 
-            var cultureResourceNames = _resourceNamesCache.GetOrAdd(resourceStreamName, key =>
+            var cacheKey = $"assembly={ResourceAssembly.FullName};resourceStreamName={resourceStreamName}";
+
+            var cultureResourceNames = _resourceNamesCache.GetOrAdd(cacheKey, key =>
             {
                 var names = new List<string>();
                 using (var cultureResourceStream = ResourceAssembly.GetManifestResourceStream(key))

--- a/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizer.cs
+++ b/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizer.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Resources;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Localization.Internal;
 
 namespace Microsoft.Framework.Localization
 {
@@ -18,12 +19,16 @@ namespace Microsoft.Framework.Localization
     /// </summary>
     public class ResourceManagerStringLocalizer : IStringLocalizer
     {
+        private static readonly ConcurrentDictionary<string, IList<string>> _resourceNamesCache =
+            new ConcurrentDictionary<string, IList<string>>();
+
         private readonly ConcurrentDictionary<string, object> _missingManifestCache =
             new ConcurrentDictionary<string, object>();
 
-        private static readonly ConcurrentDictionary<string, IList<string>> _resourceNamesCache =
-            new ConcurrentDictionary<string, IList<string>>();
-        
+        private readonly ResourceManager _resourceManager;
+        private readonly AssemblyWrapper _resourceAssemblyWrapper;
+        private readonly string _resourceBaseName;
+
         /// <summary>
         /// Creates a new <see cref="ResourceManagerStringLocalizer"/>.
         /// </summary>
@@ -34,26 +39,23 @@ namespace Microsoft.Framework.Localization
             [NotNull] ResourceManager resourceManager,
             [NotNull] Assembly resourceAssembly,
             [NotNull] string baseName)
+            : this(resourceManager, new AssemblyWrapper(resourceAssembly), baseName)
         {
-            ResourceManager = resourceManager;
-            ResourceAssembly = resourceAssembly;
-            ResourceBaseName = baseName;
+            
         }
 
         /// <summary>
-        /// The <see cref="System.Resources.ResourceManager"/> to read strings from.
+        /// Intended for testing purposes only.
         /// </summary>
-        protected ResourceManager ResourceManager { get; }
-
-        /// <summary>
-        /// The <see cref="Assembly"/> that contains the strings as embedded resources.
-        /// </summary>
-        protected Assembly ResourceAssembly { get; }
-
-        /// <summary>
-        /// The base name of the embedded resource in the <see cref="Assembly"/> that contains the strings.
-        /// </summary>
-        protected string ResourceBaseName { get; }
+        public ResourceManagerStringLocalizer(
+            [NotNull] ResourceManager resourceManager,
+            [NotNull] AssemblyWrapper resourceAssemblyWrapper,
+            [NotNull] string baseName)
+        {
+            _resourceAssemblyWrapper = resourceAssemblyWrapper;
+            _resourceManager = resourceManager;
+            _resourceBaseName = baseName;
+        }
 
         /// <inheritdoc />
         public virtual LocalizedString this[[NotNull] string name]
@@ -84,16 +86,15 @@ namespace Microsoft.Framework.Localization
         public IStringLocalizer WithCulture(CultureInfo culture)
         {
             return culture == null
-                ? new ResourceManagerStringLocalizer(ResourceManager, ResourceAssembly, ResourceBaseName)
-                : new ResourceManagerWithCultureStringLocalizer(
-                    ResourceManager,
-                    ResourceAssembly,
-                    ResourceBaseName,
+                ? new ResourceManagerStringLocalizer(_resourceManager, _resourceAssemblyWrapper, _resourceBaseName)
+                : new ResourceManagerWithCultureStringLocalizer(_resourceManager,
+                    _resourceAssemblyWrapper,
+                    _resourceBaseName,
                     culture);
         }
 
         /// <summary>
-        /// Gets a resource string from the <see cref="ResourceManager"/> and returns <c>null</c> instead of
+        /// Gets a resource string from the <see cref="_resourceManager"/> and returns <c>null</c> instead of
         /// throwing exceptions if a match isn't found.
         /// </summary>
         /// <param name="name">The name of the string resource.</param>
@@ -110,7 +111,7 @@ namespace Microsoft.Framework.Localization
 
             try
             {
-                return culture == null ? ResourceManager.GetString(name) : ResourceManager.GetString(name, culture);
+                return culture == null ? _resourceManager.GetString(name) : _resourceManager.GetString(name, culture);
             }
             catch (MissingManifestResourceException)
             {
@@ -186,19 +187,19 @@ namespace Microsoft.Framework.Localization
 
         private IList<string> GetResourceNamesForCulture(CultureInfo culture)
         {
-            var resourceStreamName = ResourceBaseName;
+            var resourceStreamName = _resourceBaseName;
             if (!string.IsNullOrEmpty(culture.Name))
             {
                 resourceStreamName += "." + culture.Name;
             }
             resourceStreamName += ".resources";
 
-            var cacheKey = $"assembly={ResourceAssembly.FullName};resourceStreamName={resourceStreamName}";
+            var cacheKey = $"assembly={_resourceAssemblyWrapper.FullName};resourceStreamName={resourceStreamName}";
 
             var cultureResourceNames = _resourceNamesCache.GetOrAdd(cacheKey, key =>
             {
                 var names = new List<string>();
-                using (var cultureResourceStream = ResourceAssembly.GetManifestResourceStream(key))
+                using (var cultureResourceStream = _resourceAssemblyWrapper.GetManifestResourceStream(key))
                 using (var resources = new ResourceReader(cultureResourceStream))
                 {
                     foreach (DictionaryEntry entry in resources)

--- a/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizerFactory.cs
+++ b/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizerFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reflection;
 using System.Resources;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Localization.Internal;
 using Microsoft.Framework.Runtime;
 
 namespace Microsoft.Framework.Localization
@@ -34,7 +35,7 @@ namespace Microsoft.Framework.Localization
         public IStringLocalizer Create([NotNull] Type resourceSource)
         {
             var typeInfo = resourceSource.GetTypeInfo();
-            var assembly = typeInfo.Assembly;
+            var assembly = new AssemblyWrapper(typeInfo.Assembly);
             var baseName = typeInfo.FullName;
             return new ResourceManagerStringLocalizer(new ResourceManager(resourceSource), assembly, baseName);
         }
@@ -49,7 +50,10 @@ namespace Microsoft.Framework.Localization
         {
             var assembly = Assembly.Load(new AssemblyName(location ?? _applicationEnvironment.ApplicationName));
 
-            return new ResourceManagerStringLocalizer(new ResourceManager(baseName, assembly), assembly, baseName);
+            return new ResourceManagerStringLocalizer(
+                new ResourceManager(baseName, assembly),
+                new AssemblyWrapper(assembly),
+                baseName);
         }
     }
 }

--- a/src/Microsoft.Framework.Localization/ResourceManagerWithCultureStringLocalizer.cs
+++ b/src/Microsoft.Framework.Localization/ResourceManagerWithCultureStringLocalizer.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved. 
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Resources;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Localization.Internal;
 
 namespace Microsoft.Framework.Localization
 {
@@ -31,6 +31,19 @@ namespace Microsoft.Framework.Localization
             [NotNull] string baseName,
             [NotNull] CultureInfo culture)
             : base(resourceManager, assembly, baseName)
+        {
+            _culture = culture;
+        }
+
+        /// <summary>
+        /// Intended for testing purposes only.
+        /// </summary>
+        public ResourceManagerWithCultureStringLocalizer(
+            [NotNull] ResourceManager resourceManager,
+            [NotNull] AssemblyWrapper assemblyWrapper,
+            [NotNull] string baseName,
+            [NotNull] CultureInfo culture)
+            : base(resourceManager, assemblyWrapper, baseName)
         {
             _culture = culture;
         }

--- a/test/Microsoft.Framework.Localization.Test/Microsoft.Framework.Localization.Test.xproj
+++ b/test/Microsoft.Framework.Localization.Test/Microsoft.Framework.Localization.Test.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>287ad58d-df34-4f16-8616-fd78fa1cadf9</ProjectGuid>
+    <RootNamespace>Microsoft.Framework.Localization.Test</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.Framework.Localization.Test/ResourceManagerStringLocalizerTest.cs
+++ b/test/Microsoft.Framework.Localization.Test/ResourceManagerStringLocalizerTest.cs
@@ -22,7 +22,11 @@ namespace Microsoft.Framework.Localization.Test
             resourceAssembly.Setup(rm => rm.GetManifestResourceStream(It.IsAny<string>()))
                 .Returns(() => MakeResourceStream());
             var baseName = "test";
-            var localizer = new ResourceManagerStringLocalizer(
+            var localizer1 = new ResourceManagerStringLocalizer(
+                resourceManager.Object,
+                resourceAssembly.Object,
+                baseName);
+            var localizer2 = new ResourceManagerStringLocalizer(
                 resourceManager.Object,
                 resourceAssembly.Object,
                 baseName);
@@ -30,7 +34,8 @@ namespace Microsoft.Framework.Localization.Test
             // Act
             for (int i = 0; i < 5; i++)
             {
-                localizer.ToList();
+                localizer1.ToList();
+                localizer2.ToList();
             }
 
             // Assert

--- a/test/Microsoft.Framework.Localization.Test/ResourceManagerStringLocalizerTest.cs
+++ b/test/Microsoft.Framework.Localization.Test/ResourceManagerStringLocalizerTest.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Resources;
-using Moq;
+using Microsoft.Framework.Localization.Internal;
 using Xunit;
 
 namespace Microsoft.Framework.Localization.Test
@@ -18,19 +18,11 @@ namespace Microsoft.Framework.Localization.Test
         {
             // Arrange
             ResourceManagerStringLocalizer.ClearResourceNamesCache();
-            var resourceManager = new Mock<ResourceManager>();
-            var resourceAssembly = new Mock<TestAssembly1>();
-            resourceAssembly.Setup(rm => rm.GetManifestResourceStream(It.IsAny<string>()))
-                .Returns(() => MakeResourceStream());
             var baseName = "test";
-            var localizer1 = new ResourceManagerStringLocalizer(
-                resourceManager.Object,
-                resourceAssembly.Object,
-                baseName);
-            var localizer2 = new ResourceManagerStringLocalizer(
-                resourceManager.Object,
-                resourceAssembly.Object,
-                baseName);
+            var resourceAssembly = new TestAssemblyWrapper();
+            var resourceManager = new TestResourceManager(baseName, resourceAssembly.Assembly);
+            var localizer1 = new ResourceManagerStringLocalizer(resourceManager, resourceAssembly, baseName);
+            var localizer2 = new ResourceManagerStringLocalizer(resourceManager, resourceAssembly, baseName);
 
             // Act
             for (int i = 0; i < 5; i++)
@@ -41,9 +33,7 @@ namespace Microsoft.Framework.Localization.Test
 
             // Assert
             var expectedCallCount = GetCultureInfoDepth(CultureInfo.CurrentUICulture);
-            resourceAssembly.Verify(
-                rm => rm.GetManifestResourceStream(It.IsAny<string>()),
-                Times.Exactly(expectedCallCount));
+            Assert.Equal(expectedCallCount, resourceAssembly.GetManifestResourceStreamCallCount);
         }
 
         [Fact]
@@ -51,24 +41,13 @@ namespace Microsoft.Framework.Localization.Test
         {
             // Arrange
             ResourceManagerStringLocalizer.ClearResourceNamesCache();
-            var resourceManager = new Mock<ResourceManager>();
-            var resourceAssembly1 = new Mock<TestAssembly1>();
-            resourceAssembly1.CallBase = true;
-            var resourceAssembly2 = new Mock<TestAssembly2>();
-            resourceAssembly2.CallBase = true;
-            resourceAssembly1.Setup(rm => rm.GetManifestResourceStream(It.IsAny<string>()))
-                .Returns(() => MakeResourceStream());
-            resourceAssembly2.Setup(rm => rm.GetManifestResourceStream(It.IsAny<string>()))
-                .Returns(() => MakeResourceStream());
             var baseName = "test";
-            var localizer1 = new ResourceManagerStringLocalizer(
-                resourceManager.Object,
-                resourceAssembly1.Object,
-                baseName);
-            var localizer2 = new ResourceManagerStringLocalizer(
-                resourceManager.Object,
-                resourceAssembly2.Object,
-                baseName);
+            var resourceAssembly1 = new TestAssemblyWrapper("Assembly1");
+            var resourceAssembly2 = new TestAssemblyWrapper("Assembly2");
+            var resourceManager1 = new TestResourceManager(baseName, resourceAssembly1.Assembly);
+            var resourceManager2 = new TestResourceManager(baseName, resourceAssembly2.Assembly);
+            var localizer1 = new ResourceManagerStringLocalizer(resourceManager1, resourceAssembly1, baseName);
+            var localizer2 = new ResourceManagerStringLocalizer(resourceManager2, resourceAssembly2, baseName);
 
             // Act
             localizer1.ToList();
@@ -76,12 +55,8 @@ namespace Microsoft.Framework.Localization.Test
 
             // Assert
             var expectedCallCount = GetCultureInfoDepth(CultureInfo.CurrentUICulture);
-            resourceAssembly1.Verify(
-                rm => rm.GetManifestResourceStream(It.IsAny<string>()),
-                Times.Exactly(expectedCallCount));
-            resourceAssembly2.Verify(
-                rm => rm.GetManifestResourceStream(It.IsAny<string>()),
-                Times.Exactly(expectedCallCount));
+            Assert.Equal(expectedCallCount, resourceAssembly1.GetManifestResourceStreamCallCount);
+            Assert.Equal(expectedCallCount, resourceAssembly2.GetManifestResourceStreamCallCount);
         }
 
         private static Stream MakeResourceStream()
@@ -114,25 +89,38 @@ namespace Microsoft.Framework.Localization.Test
             return result;
         }
 
-        public class TestAssembly1 : Assembly
+        public class TestResourceManager : ResourceManager
         {
-            public override string FullName
+            public TestResourceManager(string baseName, Assembly assembly)
+                : base(baseName, assembly)
             {
-                get
-                {
-                    return nameof(TestAssembly1);
-                }
+
+            }
+
+            public override string GetString(string name, CultureInfo culture)
+            {
+                return null;
             }
         }
 
-        public class TestAssembly2 : Assembly
+        public class TestAssemblyWrapper : AssemblyWrapper
         {
-            public override string FullName
+            private readonly string _name;
+
+            public TestAssemblyWrapper(string name = nameof(TestAssemblyWrapper))
+                : base(typeof(TestAssemblyWrapper).GetTypeInfo().Assembly)
             {
-                get
-                {
-                    return nameof(TestAssembly2);
-                }
+                _name = name;
+            }
+
+            public int GetManifestResourceStreamCallCount { get; private set; }
+
+            public override string FullName => _name;
+
+            public override Stream GetManifestResourceStream(string name)
+            {
+                GetManifestResourceStreamCallCount++;
+                return MakeResourceStream();
             }
         }
     }

--- a/test/Microsoft.Framework.Localization.Test/ResourceManagerStringLocalizerTest.cs
+++ b/test/Microsoft.Framework.Localization.Test/ResourceManagerStringLocalizerTest.cs
@@ -14,11 +14,12 @@ namespace Microsoft.Framework.Localization.Test
     public class ResourceManagerStringLocalizerTest
     {
         [Fact]
-        public void EnumeratorCachesCultureWalk()
+        public void EnumeratorCachesCultureWalkForSameAssembly()
         {
             // Arrange
+            ResourceManagerStringLocalizer.ClearResourceNamesCache();
             var resourceManager = new Mock<ResourceManager>();
-            var resourceAssembly = new Mock<TestAssembly>();
+            var resourceAssembly = new Mock<TestAssembly1>();
             resourceAssembly.Setup(rm => rm.GetManifestResourceStream(It.IsAny<string>()))
                 .Returns(() => MakeResourceStream());
             var baseName = "test";
@@ -41,6 +42,44 @@ namespace Microsoft.Framework.Localization.Test
             // Assert
             var expectedCallCount = GetCultureInfoDepth(CultureInfo.CurrentUICulture);
             resourceAssembly.Verify(
+                rm => rm.GetManifestResourceStream(It.IsAny<string>()),
+                Times.Exactly(expectedCallCount));
+        }
+
+        [Fact]
+        public void EnumeratorCacheIsScopedByAssembly()
+        {
+            // Arrange
+            ResourceManagerStringLocalizer.ClearResourceNamesCache();
+            var resourceManager = new Mock<ResourceManager>();
+            var resourceAssembly1 = new Mock<TestAssembly1>();
+            resourceAssembly1.CallBase = true;
+            var resourceAssembly2 = new Mock<TestAssembly2>();
+            resourceAssembly2.CallBase = true;
+            resourceAssembly1.Setup(rm => rm.GetManifestResourceStream(It.IsAny<string>()))
+                .Returns(() => MakeResourceStream());
+            resourceAssembly2.Setup(rm => rm.GetManifestResourceStream(It.IsAny<string>()))
+                .Returns(() => MakeResourceStream());
+            var baseName = "test";
+            var localizer1 = new ResourceManagerStringLocalizer(
+                resourceManager.Object,
+                resourceAssembly1.Object,
+                baseName);
+            var localizer2 = new ResourceManagerStringLocalizer(
+                resourceManager.Object,
+                resourceAssembly2.Object,
+                baseName);
+
+            // Act
+            localizer1.ToList();
+            localizer2.ToList();
+
+            // Assert
+            var expectedCallCount = GetCultureInfoDepth(CultureInfo.CurrentUICulture);
+            resourceAssembly1.Verify(
+                rm => rm.GetManifestResourceStream(It.IsAny<string>()),
+                Times.Exactly(expectedCallCount));
+            resourceAssembly2.Verify(
                 rm => rm.GetManifestResourceStream(It.IsAny<string>()),
                 Times.Exactly(expectedCallCount));
         }
@@ -75,9 +114,26 @@ namespace Microsoft.Framework.Localization.Test
             return result;
         }
 
-        public class TestAssembly : Assembly
+        public class TestAssembly1 : Assembly
         {
+            public override string FullName
+            {
+                get
+                {
+                    return nameof(TestAssembly1);
+                }
+            }
+        }
 
+        public class TestAssembly2 : Assembly
+        {
+            public override string FullName
+            {
+                get
+                {
+                    return nameof(TestAssembly2);
+                }
+            }
         }
     }
 }

--- a/test/Microsoft.Framework.Localization.Test/ResourceManagerStringLocalizerTest.cs
+++ b/test/Microsoft.Framework.Localization.Test/ResourceManagerStringLocalizerTest.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Resources;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Framework.Localization.Test
+{
+    public class ResourceManagerStringLocalizerTest
+    {
+        [Fact]
+        public void EnumeratorCachesCultureWalk()
+        {
+            // Arrange
+            var resourceManager = new Mock<ResourceManager>();
+            var resourceAssembly = new Mock<TestAssembly>();
+            resourceAssembly.Setup(rm => rm.GetManifestResourceStream(It.IsAny<string>()))
+                .Returns(() => MakeResourceStream());
+            var baseName = "test";
+            var localizer = new ResourceManagerStringLocalizer(
+                resourceManager.Object,
+                resourceAssembly.Object,
+                baseName);
+
+            // Act
+            for (int i = 0; i < 5; i++)
+            {
+                localizer.ToList();
+            }
+
+            // Assert
+            var expectedCallCount = GetCultureInfoDepth(CultureInfo.CurrentUICulture);
+            resourceAssembly.Verify(
+                rm => rm.GetManifestResourceStream(It.IsAny<string>()),
+                Times.Exactly(expectedCallCount));
+        }
+
+        private static Stream MakeResourceStream()
+        {
+            var stream = new MemoryStream();
+            var resourceWriter = new ResourceWriter(stream);            
+            resourceWriter.AddResource("TestName", "value");
+            resourceWriter.Generate();
+            stream.Position = 0;
+            return stream;
+        }
+
+        private static int GetCultureInfoDepth(CultureInfo culture)
+        {
+            var result = 0;
+            var currentCulture = culture;
+
+            while (true)
+            {
+                result++;
+
+                if (currentCulture == currentCulture.Parent)
+                {
+                    break;
+                }
+
+                currentCulture = currentCulture.Parent;
+            }
+
+            return result;
+        }
+
+        public class TestAssembly : Assembly
+        {
+
+        }
+    }
+}

--- a/test/Microsoft.Framework.Localization.Test/project.json
+++ b/test/Microsoft.Framework.Localization.Test/project.json
@@ -1,16 +1,17 @@
 {
-    "dependencies": {
-        "Moq": "4.2.1502.911",
-        "xunit": "2.1.0-*",
-        "xunit.runner.dnx": "2.1.0-*",
-        "Microsoft.Framework.Localization": "1.0.0-*"
-    },
+  "dependencies": {
+    "xunit": "2.1.0-*",
+    "xunit.runner.dnx": "2.1.0-*",
+    "Microsoft.Framework.Localization": "1.0.0-*",
+    "System.Reflection": "4.0.10-*"
+  },
 
-    "commands": {
-        "test": "xunit.runner.dnx"
-    },
+  "commands": {
+    "test": "xunit.runner.dnx"
+  },
 
-    "frameworks": {
-        "dnx451": { }
-    }
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": { }
+  }
 }

--- a/test/Microsoft.Framework.Localization.Test/project.json
+++ b/test/Microsoft.Framework.Localization.Test/project.json
@@ -1,0 +1,16 @@
+{
+    "dependencies": {
+        "Moq": "4.2.1502.911",
+        "xunit": "2.1.0-*",
+        "xunit.runner.dnx": "2.1.0-*",
+        "Microsoft.Framework.Localization": "1.0.0-*"
+    },
+
+    "commands": {
+        "test": "xunit.runner.dnx"
+    },
+
+    "frameworks": {
+        "dnx451": { }
+    }
+}


### PR DESCRIPTION
Implemented caching of the walk of the `CultureInfo` tree to get resource names. Includes tests.

#15 

@davidfowl @Eilon @muratg 