### PR TITLE
Simplify generating culture names

### DIFF
--- a/src/CultureInfoGenerator/Program.cs
+++ b/src/CultureInfoGenerator/Program.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using Microsoft.Framework.Runtime;
 using Microsoft.Win32;
 
@@ -58,24 +59,7 @@ namespace Microsoft.Framework.Globalization
                     | CultureTypes.InstalledWin32Cultures
                     | CultureTypes.SpecificCultures);
 
-                var format = "            \"{0}\"";
-
-                for (int i = 0; i < cultures.Length; i++)
-                {
-                    var culture = cultures[i];
-
-                    writer.Write(format, culture.Name);
-
-                    if (i < cultures.Length - 1)
-                    {
-                        writer.WriteLine(",");
-                    }
-                    else
-                    {
-                        // Last entry
-                        writer.WriteLine();
-                    }
-                }
+                writer.WriteLine(string.Join($",{Environment.NewLine}", cultures.Select(c => $"            \"{c.Name}\"")));
                 writer.WriteLine(
 @"        };
     }


### PR DESCRIPTION
Simplify generating culture names using simple LINQ query with newly format style. 

For better performance we can fetch the culture names rather than fetching the entire ```CultureInfo``` list for all the cultures