### PR TITLE
Make 'ResourceManagerStringLocalizer' overload internal

### DIFF
--- a/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizer.cs
+++ b/src/Microsoft.Framework.Localization/ResourceManagerStringLocalizer.cs
@@ -43,10 +43,7 @@ namespace Microsoft.Framework.Localization
             
         }
 
-        /// <summary>
-        /// Intended for testing purposes only.
-        /// </summary>
-        public ResourceManagerStringLocalizer(
+        internal ResourceManagerStringLocalizer(
             [NotNull] ResourceManager resourceManager,
             [NotNull] AssemblyWrapper resourceAssemblyWrapper,
             [NotNull] string baseName,


### PR DESCRIPTION
While we have ```InternalsVisibleTo``` in this line of https://github.com/aspnet/Localization/blob/dev/src/Microsoft.Framework.Localization/Properties/AssemblyInfo.cs#L6, it will be nice to modify the access modifier for ```ResourceManagerStringLocalizer``` overload to ```internal``` rather than ```public``` because the intend for this overload to be used for testing purpose only