### PR TITLE
Fix namespace typo

### DIFF
--- a/test/Microsoft.Framework.Localization.Tests/ResourceManagerStringLocalizerTest.cs
+++ b/test/Microsoft.Framework.Localization.Tests/ResourceManagerStringLocalizerTest.cs
@@ -9,7 +9,7 @@ using System.Resources;
 using Microsoft.Framework.Localization.Internal;
 using Xunit;
 
-namespace Microsoft.Framework.Localization.Test
+namespace Microsoft.Framework.Localization.Tests
 {
     public class ResourceManagerStringLocalizerTest
     {


### PR DESCRIPTION
Base on my commit https://github.com/aspnet/Localization/commit/5f83c0df434d117abbca89dc7b5e2e2286d738c3, I forgot to rename the namespace of ```ResourceManagerStringLocalizerTest``` class, so i did this fix