### PR TITLE
Sets 'en-US' as default culture in cultures list

### DIFF
--- a/samples/LocalizationSample/Startup.cs
+++ b/samples/LocalizationSample/Startup.cs
@@ -130,7 +130,7 @@ $@"<!doctype html>
 
         private static async System.Threading.Tasks.Task WriteCultureSelectOptions(HttpContext context)
         {
-            await context.Response.WriteAsync($"    <option value=\"\">-- select --</option>");
+            await context.Response.WriteAsync($"    <option value=\"{new CultureInfo("en-US").Name}\">-- select --</option>");
             await context.Response.WriteAsync($"    <option value=\"{new CultureInfo("en-US").Name}\">{new CultureInfo("en-US").DisplayName}</option>");
             await context.Response.WriteAsync($"    <option value=\"{new CultureInfo("en-AU").Name}\">{new CultureInfo("en-AU").DisplayName}</option>");
             await context.Response.WriteAsync($"    <option value=\"{new CultureInfo("en-GB").Name}\">{new CultureInfo("en-GB").DisplayName}</option>");


### PR DESCRIPTION
The "-- select --" option enforce the culture to be invalid, it will be nice if we make the default culture  ```en-US```