### PR TITLE
Fix project name in AssemblyInfo

### DIFF
--- a/src/Microsoft.Framework.Localization/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.Localization/Properties/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.Localization.Test")]
+[assembly: InternalsVisibleTo("Microsoft.Framework.Localization.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: NeutralResourcesLanguage("en-us")]


### PR DESCRIPTION
Fix project name ```Microsoft.Framework.Localization.Tests``` in AssemblyInfo.cs
/cc @kirthik @Eilon
