### PR TITLE
Make the ResourceManagerStringLocalizerFactory cache localizer instances

### DIFF
--- a/src/Microsoft.Extensions.Localization/ResourceManagerStringLocalizer.cs
+++ b/src/Microsoft.Extensions.Localization/ResourceManagerStringLocalizer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
@@ -18,9 +17,7 @@ namespace Microsoft.Extensions.Localization
     /// </summary>
     public class ResourceManagerStringLocalizer : IStringLocalizer
     {
-        private readonly ConcurrentDictionary<string, object> _missingManifestCache =
-            new ConcurrentDictionary<string, object>();
-
+        private readonly Dictionary<string, object> _missingManifestCache = new Dictionary<string, object>();
         private readonly IResourceNamesCache _resourceNamesCache;
         private readonly ResourceManager _resourceManager;
         private readonly AssemblyWrapper _resourceAssemblyWrapper;
@@ -188,7 +185,7 @@ namespace Microsoft.Extensions.Localization
             }
             catch (MissingManifestResourceException)
             {
-                _missingManifestCache.TryAdd(cacheKey, null);
+                _missingManifestCache.Add(cacheKey, null);
                 return null;
             }
         }


### PR DESCRIPTION
Turns out the performance of the `ResourceManagerStringLocalizer` is terrible in an actual app due to the way `ResourceManager` works. You really need to keep instances of `ResourceManager` around forever as it does a lot of its own caching internally and the existing localization experience in .NET apps today is designed around this premise.

The simplest change was to just make the `ResourceManagerSringLocazlierFactory` cache the instances of `ResourceManagerStringLocalizer` it creates, as they hold the `ResourceManager` inside of themselves, as well as a cache of missing resource manifest names.

This change gets us to a place where the `ResourceManager` instances are used more like they were intended to be, as well as the cache of missing resource lookups being effectively global. Performance gains are huge, e.g. localized home page from starter web template goes from >6s per page load to <20ms (that's not a typo, 6,700ms to 15ms, yes the `ResourceManager` **really** needs to be cached).

- #156

@Eilon @ryanbrandenburg