### PR TITLE
Add missing 'Microsoft.Extensions.OptionsModel' namepace

### DIFF
--- a/test/Microsoft.Extensions.Localization.Tests/project.json
+++ b/test/Microsoft.Extensions.Localization.Tests/project.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
     "Microsoft.Extensions.Localization": "1.0.0-*",
+    "Microsoft.Extensions.OptionsModel": "1.0.0-*",
     "xunit": "2.1.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },


### PR DESCRIPTION
After the latest commits, there's a namespace lost by mistake, so this fixes issue #171 
/cc @DamianEdwards @Eilon 