### PR TITLE
Added support for hierarchical culture fallback

### DIFF
--- a/src/Microsoft.AspNet.Localization/RequestLocalizationOptions.cs
+++ b/src/Microsoft.AspNet.Localization/RequestLocalizationOptions.cs
@@ -51,6 +51,33 @@ namespace Microsoft.AspNet.Localization
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to set a request culture to an ancestor culture in the case the
+        /// culture determined by the configured <see cref="IRequestCultureProvider"/>s is not in the
+        /// <see cref="SupportedCultures"/> list but an ancestor culture is.
+        /// Defaults to <c>true</c>;
+        /// </summary>
+        /// <example>
+        /// If this property is <c>true</c> and the application is configured to support the culture "fr", but not the
+        /// culture "fr-FR", and a configured <see cref="IRequestCultureProvider"/> determines a request's culture is
+        /// "fr-FR", then the request's culture will be set to the culture "fr", as it is an ancestor of "fr-FR".
+        /// </example>
+        public bool FallbackToAncestorCulture { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to set a request UI culture to an ancestor culture in the case the
+        /// UI culture determined by the configured <see cref="IRequestCultureProvider"/>s is not in the
+        /// <see cref="SupportedUICultures"/> list but an ancestor culture is.
+        /// Defaults to <c>true</c>;
+        /// </summary>
+        /// <example>
+        /// If this property is <c>true</c> and the application is configured to support the UI culture "fr", but not
+        /// the UI culture "fr-FR", and a configured <see cref="IRequestCultureProvider"/> determines a request's UI
+        /// culture is "fr-FR", then the request's UI culture will be set to the culture "fr", as it is an ancestor of
+        /// "fr-FR".
+        /// </example>
+        public bool FallbackToAncestorUICulture { get; set; } = true;
+
+        /// <summary>
         /// The cultures supported by the application. The <see cref="RequestLocalizationMiddleware"/> will only set
         /// the current request culture to an entry in this list.
         /// Defaults to <see cref="CultureInfo.CurrentCulture"/>.

--- a/test/Microsoft.AspNet.Localization.FunctionalTests/LocalizationTest.cs
+++ b/test/Microsoft.AspNet.Localization.FunctionalTests/LocalizationTest.cs
@@ -30,6 +30,46 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
                 "Bonjour from StartupResourcesInFolder Bonjour from Test in resources folder Bonjour from Customer in resources folder");
         }
 
+        [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [InlineData(RuntimeFlavor.Clr, "http://localhost:5070/", RuntimeArchitecture.x86)]
+        [InlineData(RuntimeFlavor.CoreClr, "http://localhost:5071/", RuntimeArchitecture.x86)]
+        public Task Localization_ResourcesInFolder_ReturnLocalizedValue_WithCultureFallback_Windows(
+            RuntimeFlavor runtimeFlavor,
+            string applicationBaseUrl,
+            RuntimeArchitecture runtimeArchitechture)
+        {
+            var testRunner = new TestRunner();
+            return testRunner.RunTestAndVerifyResponse(
+                runtimeFlavor,
+                runtimeArchitechture,
+                applicationBaseUrl,
+                "ResourcesInFolder",
+                "fr-FR-test",
+                "Bonjour from StartupResourcesInFolder Bonjour from Test in resources folder Bonjour from Customer in resources folder");
+        }
+
+        [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [InlineData(RuntimeFlavor.Clr, "http://localhost:5070/", RuntimeArchitecture.x86)]
+        [InlineData(RuntimeFlavor.CoreClr, "http://localhost:5071/", RuntimeArchitecture.x86)]
+        public Task Localization_ResourcesInFolder_ReturnNonLocalizedValue_CultureHierarchyTooDeep_Windows(
+            RuntimeFlavor runtimeFlavor,
+            string applicationBaseUrl,
+            RuntimeArchitecture runtimeArchitechture)
+        {
+            var testRunner = new TestRunner();
+            return testRunner.RunTestAndVerifyResponse(
+                runtimeFlavor,
+                runtimeArchitechture,
+                applicationBaseUrl,
+                "ResourcesInFolder",
+                "fr-FR-test-again-too-deep-to-work",
+                "Hello Hello Hello");
+        }
+
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Windows)]
         [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
@@ -47,6 +87,21 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
 
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Windows)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
+        public Task Localization_ResourcesInFolder_ReturnLocalizedValue_WithCultureFallback_Mono()
+        {
+            var testRunner = new TestRunner();
+            return testRunner.RunTestAndVerifyResponse(
+                RuntimeFlavor.Mono,
+                RuntimeArchitecture.x86,
+                "http://localhost:5072",
+                "ResourcesInFolder",
+                "fr-FR-test",
+                "Bonjour from StartupResourcesInFolder Bonjour from Test in resources folder Bonjour from Customer in resources folder");
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Windows)]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public Task Localization_ResourcesInFolder_ReturnLocalizedValue_CoreCLR_NonWindows()
         {
@@ -57,6 +112,21 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
                 "http://localhost:5073/",
                 "ResourcesInFolder",
                 "fr-FR",
+                "Bonjour from StartupResourcesInFolder Bonjour from Test in resources folder Bonjour from Customer in resources folder");
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Windows)]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        public Task Localization_ResourcesInFolder_ReturnLocalizedValue_WithCultureFallback_CoreCLR_NonWindows()
+        {
+            var testRunner = new TestRunner();
+            return testRunner.RunTestAndVerifyResponse(
+                RuntimeFlavor.CoreClr,
+                RuntimeArchitecture.x64,
+                "http://localhost:5073/",
+                "ResourcesInFolder",
+                "fr-FR-test",
                 "Bonjour from StartupResourcesInFolder Bonjour from Test in resources folder Bonjour from Customer in resources folder");
         }
 


### PR DESCRIPTION
- Enabled by default and configred by `RequestLocalizationOptions.FallbackToAncestorCulture`/`FallbackToAncestorUICulture`
- Tries all candidate cultures first before trimming the list to parents and trying again (breadth first), until a match is found or none is found
- Updated functional tests to cover fallback case
- #112

@ryanbrandenburg @Eilon @rynowak @lodejard 