### PR TITLE
FunctionalTest for LocalizationSample

### DIFF
--- a/test/Microsoft.AspNet.Localization.FunctionalTests/LocalizationSampleTest.cs
+++ b/test/Microsoft.AspNet.Localization.FunctionalTests/LocalizationSampleTest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Testing;
+using Microsoft.AspNet.Testing.xunit;
+using Xunit;
+
+namespace Microsoft.AspNet.Localization.FunctionalTests
+{
+    public class LocalizationSampleTest
+    {
+        private static readonly string _applicationPath = Path.GetFullPath(Path.Combine("../../samples", "LocalizationSample"));
+        
+        [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [InlineData(RuntimeFlavor.Clr, "http://localhost:5070/", RuntimeArchitecture.x86)]
+        [InlineData(RuntimeFlavor.CoreClr, "http://localhost:5071/", RuntimeArchitecture.x86)]
+        public Task RunSite_WindowsOnly(RuntimeFlavor runtimeFlavor, string applicationBaseUrl, RuntimeArchitecture runtimeArchitecture)
+        {
+            var testRunner = new TestRunner(_applicationPath);
+            return testRunner.RunTestAndVerifyResponseHeading(
+                runtimeFlavor,
+                runtimeArchitecture,
+                applicationBaseUrl,
+                "My/Resources",
+                "fr-FR",
+                "<h1>Bonjour</h1>");
+        }
+        
+        [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Windows)]
+        [InlineData(RuntimeFlavor.Mono, "http://localhost:5070/", RuntimeArchitecture.x64)]
+        [InlineData(RuntimeFlavor.CoreClr, "http://localhost:5071/", RuntimeArchitecture.x64)]
+        public Task RunSite_NonWindowsOnly(RuntimeFlavor runtimeFlavor, string applicationBaseUrl, RuntimeArchitecture runtimeArchitecture)
+        {
+            var testRunner = new TestRunner(_applicationPath);
+            return testRunner.RunTestAndVerifyResponseHeading(
+                runtimeFlavor,
+                runtimeArchitecture,
+                applicationBaseUrl,
+                "My/Resources",
+                "fr-FR",
+                "<h1>Bonjour</h1>");
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Localization.FunctionalTests/LocalizationTest.cs
+++ b/test/Microsoft.AspNet.Localization.FunctionalTests/LocalizationTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved. 
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Server.Testing;
 using Microsoft.AspNet.Testing.xunit;
@@ -10,6 +11,8 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
 {
     public class LocalizationTest
     {
+        private static readonly string _applicationPath = Path.GetFullPath(Path.Combine("..", "LocalizationWebsite"));
+        
         [ConditionalTheory]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
@@ -18,12 +21,12 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
         public Task Localization_ResourcesInFolder_ReturnLocalizedValue_Windows(
             RuntimeFlavor runtimeFlavor,
             string applicationBaseUrl,
-            RuntimeArchitecture runtimeArchitechture)
+            RuntimeArchitecture runtimeArchitecture)
         {
-            var testRunner = new TestRunner();
+            var testRunner = new TestRunner(_applicationPath);
             return testRunner.RunTestAndVerifyResponse(
                 runtimeFlavor,
-                runtimeArchitechture,
+                runtimeArchitecture,
                 applicationBaseUrl,
                 "ResourcesInFolder",
                 "fr-FR",
@@ -38,12 +41,12 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
         public Task Localization_ResourcesInFolder_ReturnLocalizedValue_WithCultureFallback_Windows(
             RuntimeFlavor runtimeFlavor,
             string applicationBaseUrl,
-            RuntimeArchitecture runtimeArchitechture)
+            RuntimeArchitecture runtimeArchitecture)
         {
-            var testRunner = new TestRunner();
+            var testRunner = new TestRunner(_applicationPath);
             return testRunner.RunTestAndVerifyResponse(
                 runtimeFlavor,
-                runtimeArchitechture,
+                runtimeArchitecture,
                 applicationBaseUrl,
                 "ResourcesInFolder",
                 "fr-FR-test",
@@ -58,12 +61,12 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
         public Task Localization_ResourcesInFolder_ReturnNonLocalizedValue_CultureHierarchyTooDeep_Windows(
             RuntimeFlavor runtimeFlavor,
             string applicationBaseUrl,
-            RuntimeArchitecture runtimeArchitechture)
+            RuntimeArchitecture runtimeArchitecture)
         {
-            var testRunner = new TestRunner();
+            var testRunner = new TestRunner(_applicationPath);
             return testRunner.RunTestAndVerifyResponse(
                 runtimeFlavor,
-                runtimeArchitechture,
+                runtimeArchitecture,
                 applicationBaseUrl,
                 "ResourcesInFolder",
                 "fr-FR-test-again-too-deep-to-work",
@@ -75,7 +78,7 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
         [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
         public Task Localization_ResourcesInFolder_ReturnLocalizedValue_Mono()
         {
-            var testRunner = new TestRunner();
+            var testRunner = new TestRunner(_applicationPath);
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.Mono,
                 RuntimeArchitecture.x86,
@@ -90,7 +93,7 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
         [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
         public Task Localization_ResourcesInFolder_ReturnLocalizedValue_WithCultureFallback_Mono()
         {
-            var testRunner = new TestRunner();
+            var testRunner = new TestRunner(_applicationPath);
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.Mono,
                 RuntimeArchitecture.x86,
@@ -105,7 +108,7 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public Task Localization_ResourcesInFolder_ReturnLocalizedValue_CoreCLR_NonWindows()
         {
-            var testRunner = new TestRunner();
+            var testRunner = new TestRunner(_applicationPath);
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.CoreClr,
                 RuntimeArchitecture.x64,
@@ -120,7 +123,7 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public Task Localization_ResourcesInFolder_ReturnLocalizedValue_WithCultureFallback_CoreCLR_NonWindows()
         {
-            var testRunner = new TestRunner();
+            var testRunner = new TestRunner(_applicationPath);
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.CoreClr,
                 RuntimeArchitecture.x64,
@@ -138,12 +141,12 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
         public Task Localization_ResourcesAtRootFolder_ReturnLocalizedValue_Windows(
             RuntimeFlavor runtimeFlavor,
             string applicationBaseUrl,
-            RuntimeArchitecture runtimeArchitechture)
+            RuntimeArchitecture runtimeArchitecture)
         {
-            var testRunner = new TestRunner();
+            var testRunner = new TestRunner(_applicationPath);
             return testRunner.RunTestAndVerifyResponse(
                 runtimeFlavor,
-                runtimeArchitechture,
+                runtimeArchitecture,
                 applicationBaseUrl,
                 "ResourcesAtRootFolder",
                 "fr-FR",
@@ -155,7 +158,7 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
         [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
         public Task Localization_ResourcesAtRootFolder_ReturnLocalizedValue_Mono()
         {
-            var testRunner = new TestRunner();
+            var testRunner = new TestRunner(_applicationPath);
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.Mono,
                 RuntimeArchitecture.x86,
@@ -170,7 +173,7 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public Task Localization_ResourcesAtRootFolder_ReturnLocalizedValue_CoreCLR_NonWindows()
         {
-            var testRunner = new TestRunner();
+            var testRunner = new TestRunner(_applicationPath);
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.CoreClr,
                 RuntimeArchitecture.x64,

--- a/test/Microsoft.AspNet.Localization.FunctionalTests/TestRunner.cs
+++ b/test/Microsoft.AspNet.Localization.FunctionalTests/TestRunner.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
 using System;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -14,21 +13,26 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
 {
     public class TestRunner
     {
-        public async Task RunTestAndVerifyResponse(
+        private string _applicationPath;
+        
+        public TestRunner(string applicationPath){
+            _applicationPath = applicationPath;
+        }
+        
+        private async Task<string> RunTestAndGetResponse(
             RuntimeFlavor runtimeFlavor,
-            RuntimeArchitecture runtimeArchitechture,
+            RuntimeArchitecture runtimeArchitecture,
             string applicationBaseUrl,
             string environmentName,
-            string locale,
-            string expectedText)
+            string locale)
         {
             var logger = new LoggerFactory()
                             .AddConsole()
-                            .CreateLogger(string.Format("Localization Test Site:{0}:{1}:{2}", ServerType.Kestrel, runtimeFlavor, runtimeArchitechture));
+                            .CreateLogger(string.Format("Localization Test Site:{0}:{1}:{2}", ServerType.Kestrel, runtimeFlavor, runtimeArchitecture));
 
             using (logger.BeginScope("LocalizationTest"))
             {
-                var deploymentParameters = new DeploymentParameters(GetApplicationPath(), ServerType.Kestrel, runtimeFlavor, runtimeArchitechture)
+                var deploymentParameters = new DeploymentParameters(_applicationPath, ServerType.Kestrel, runtimeFlavor, runtimeArchitecture)
                 {
                     ApplicationBaseUriHint = applicationBaseUrl,
                     Command = "web",
@@ -54,16 +58,36 @@ namespace Microsoft.AspNet.Localization.FunctionalTests
                         return httpClient.GetAsync(string.Empty);
                     }, logger, deploymentResult.HostShutdownToken);
 
-                    var responseText = await response.Content.ReadAsStringAsync();
-                    Console.WriteLine("Response Text " + responseText);
-                    Assert.Equal(expectedText, responseText);
+                    return await response.Content.ReadAsStringAsync();
                 }
             }
         }
-
-        public string GetApplicationPath()
+        
+        public async Task RunTestAndVerifyResponse(
+            RuntimeFlavor runtimeFlavor,
+            RuntimeArchitecture runtimeArchitecture,
+            string applicationBaseUrl,
+            string environmentName,
+            string locale,
+            string expectedText)
         {
-            return Path.GetFullPath(Path.Combine("..", "LocalizationWebsite"));
+            var responseText = await RunTestAndGetResponse(runtimeFlavor, runtimeArchitecture, applicationBaseUrl, environmentName, locale);
+            Console.WriteLine("Response Text " + responseText);
+            Assert.Equal(expectedText, responseText);
+        }
+        
+        public async Task RunTestAndVerifyResponseHeading(
+            RuntimeFlavor runtimeFlavor,
+            RuntimeArchitecture runtimeArchitecture,
+            string applicationBaseUrl,
+            string environmentName,
+            string locale,
+            string expectedHeadingText)
+        {
+            var responseText = await RunTestAndGetResponse(runtimeFlavor, runtimeArchitecture, applicationBaseUrl, environmentName, locale);
+            var headingIndex = responseText.IndexOf(expectedHeadingText);
+            Console.WriteLine("Response Header " + responseText);
+            Assert.True(headingIndex >= 0);
         }
     }
 }


### PR DESCRIPTION
I made this PR long time back to fix issue #148, I was worrying because the current functional test is compare the actual html content which is not effecient in the Localization Sample, so I introduce a new method to check if a heading part is localized, hopefully this enough in this case
Thanks @DamianEdwards for the sample you push here https://github.com/aspnet/Entropy/pull/83