### PR TITLE
Adding TimeZoneInfo to the RequestCulture class

### DIFF
--- a/samples/LocalizationSample/Startup.cs
+++ b/samples/LocalizationSample/Startup.cs
@@ -25,7 +25,7 @@ namespace LocalizationSample
         {
             app.UseRequestLocalization(options =>
             {
-                options.DefaultRequestCulture = new RequestCulture("en-US");
+                options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
 
                 // Set options here to change middleware behavior
                 options.SupportedCultures = new List<CultureInfo>

--- a/src/Microsoft.AspNet.Localization/RequestCulture.cs
+++ b/src/Microsoft.AspNet.Localization/RequestCulture.cs
@@ -16,8 +16,9 @@ namespace Microsoft.AspNet.Localization
         /// properties set to the same <see cref="CultureInfo"/> value.
         /// </summary>
         /// <param name="culture">The <see cref="CultureInfo"/> for the request.</param>
-        public RequestCulture(CultureInfo culture)
-            : this(culture, culture)
+		/// <param name="timeZone">The <see cref="TimeZoneInfo"/> for the request.</param>
+        public RequestCulture(CultureInfo culture, TimeZoneInfo timeZone)
+            : this(culture, culture, timeZone)
         {
         }
 
@@ -26,8 +27,9 @@ namespace Microsoft.AspNet.Localization
         /// properties set to the same <see cref="CultureInfo"/> value.
         /// </summary>
         /// <param name="culture">The culture for the request.</param>
-        public RequestCulture(string culture)
-            : this(culture, culture)
+		/// <param name="timeZoneId">The time zone for the request.</param>
+        public RequestCulture(string culture, string timeZoneId)
+            : this(culture, culture, timeZoneId)
         {
         }
 
@@ -37,18 +39,20 @@ namespace Microsoft.AspNet.Localization
         /// </summary>
         /// <param name="culture">The culture for the request to be used for formatting.</param>
         /// <param name="uiCulture">The culture for the request to be used for text, i.e. language.</param>
-        public RequestCulture(string culture, string uiCulture)
-            : this (new CultureInfo(culture), new CultureInfo(uiCulture))
+		/// <param name="timeZoneId">The time zone for the request to be used for dates.</param>
+        public RequestCulture(string culture, string uiCulture, string timeZoneId)
+            : this (new CultureInfo(culture), new CultureInfo(uiCulture), TimeZoneInfo.FindSystemTimeZoneById(timeZoneId))
         {
         }
 
         /// <summary>
-        /// Creates a new <see cref="RequestCulture"/> object has its <see cref="Culture"/> and <see cref="UICulture"/>
-        /// properties set to the respective <see cref="CultureInfo"/> values provided.
+        /// Creates a new <see cref="RequestCulture"/> object has its <see cref="Culture"/> and <see cref="UICulture"/> and <see cref="TimeZoneInfo"/>
+        /// properties set to the respective <see cref="CultureInfo"/> and <see cref="TimeZoneInfo"/> values provided.
         /// </summary>
         /// <param name="culture">The <see cref="CultureInfo"/> for the request to be used for formatting.</param>
         /// <param name="uiCulture">The <see cref="CultureInfo"/> for the request to be used for text, i.e. language.</param>
-        public RequestCulture(CultureInfo culture, CultureInfo uiCulture)
+		/// <param name="timeZone">The <see cref="TimeZoneInfo"/> for the request to be used for dates.</param>
+        public RequestCulture(CultureInfo culture, CultureInfo uiCulture, TimeZoneInfo timeZone)
         {
             if (culture == null)
             {
@@ -60,8 +64,13 @@ namespace Microsoft.AspNet.Localization
                 throw new ArgumentNullException(nameof(uiCulture));
             }
 
-            Culture = culture;
+			if (timeZone == null) {
+				throw new ArgumentNullException(nameof(timeZone));
+			}
+
+			Culture = culture;
             UICulture = uiCulture;
+			TimeZone = timeZone;
         }
 
         /// <summary>
@@ -73,5 +82,7 @@ namespace Microsoft.AspNet.Localization
         /// Gets the <see cref="CultureInfo"/> for the request to be used for text, i.e. language;
         /// </summary>
         public CultureInfo UICulture { get; }
+
+		public TimeZoneInfo TimeZone { get; }
     }
 }

--- a/src/Microsoft.AspNet.Localization/RequestLocalizationMiddleware.cs
+++ b/src/Microsoft.AspNet.Localization/RequestLocalizationMiddleware.cs
@@ -73,6 +73,7 @@ namespace Microsoft.AspNet.Localization
 
                         CultureInfo cultureInfo = null;
                         CultureInfo uiCultureInfo = null;
+						TimeZoneInfo timeZoneInfo = null;
                         if (_options.SupportedCultures != null)
                         {
                             cultureInfo = GetCultureInfo(
@@ -104,7 +105,7 @@ namespace Microsoft.AspNet.Localization
                             uiCultureInfo = _options.DefaultRequestCulture.UICulture;
                         }
 
-                        var result = new RequestCulture(cultureInfo, uiCultureInfo);
+                        var result = new RequestCulture(cultureInfo, uiCultureInfo, timeZoneInfo);
 
                         if (result != null)
                         {

--- a/src/Microsoft.AspNet.Localization/RequestLocalizationOptions.cs
+++ b/src/Microsoft.AspNet.Localization/RequestLocalizationOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.Localization
     public class RequestLocalizationOptions
     {
         private RequestCulture _defaultRequestCulture =
-            new RequestCulture(CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture);
+            new RequestCulture(CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture, TimeZoneInfo.Local);
 
         /// <summary>
         /// Creates a new <see cref="RequestLocalizationOptions"/> with default values.

--- a/test/LocalizationWebsite/StartupResourcesAtRootFolder.cs
+++ b/test/LocalizationWebsite/StartupResourcesAtRootFolder.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNet.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace LocalizationWebsite
 {
@@ -31,7 +32,7 @@ namespace LocalizationWebsite
 
             app.UseRequestLocalization(options =>
             {
-                options.DefaultRequestCulture = new RequestCulture("en-US");
+                options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                 options.SupportedCultures = new List<CultureInfo>()
                 {
                     new CultureInfo("fr-FR")

--- a/test/LocalizationWebsite/StartupResourcesInFolder.cs
+++ b/test/LocalizationWebsite/StartupResourcesInFolder.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNet.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace LocalizationWebsite
 {
@@ -31,7 +32,7 @@ namespace LocalizationWebsite
 
             app.UseRequestLocalization(options =>
             {
-                options.DefaultRequestCulture = new RequestCulture("en-US");
+                options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                 options.SupportedCultures = new List<CultureInfo>()
                 {
                     new CultureInfo("fr-FR")

--- a/test/Microsoft.AspNet.Localization.Tests/AcceptLanguageHeaderRequestCultureProviderTest.cs
+++ b/test/Microsoft.AspNet.Localization.Tests/AcceptLanguageHeaderRequestCultureProviderTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNet.Http.Features;
 using Microsoft.AspNet.Localization;
 using Microsoft.AspNet.TestHost;
 using Xunit;
+using System;
 
 namespace Microsoft.Extensions.Localization.Tests
 {
@@ -23,7 +24,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA"),
@@ -57,7 +58,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("fr-FR");
+                        options.DefaultRequestCulture = new RequestCulture("fr-FR", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA"),
@@ -90,7 +91,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("fr-FR");
+                        options.DefaultRequestCulture = new RequestCulture("fr-FR", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA"),
@@ -124,7 +125,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-YE")

--- a/test/Microsoft.AspNet.Localization.Tests/CookieRequestCultureProviderTest.cs
+++ b/test/Microsoft.AspNet.Localization.Tests/CookieRequestCultureProviderTest.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNet.Localization;
 using Microsoft.AspNet.TestHost;
 using Microsoft.Net.Http.Headers;
 using Xunit;
+using System;
 
 namespace Microsoft.Extensions.Localization.Tests
 {
@@ -24,7 +25,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA")
@@ -50,7 +51,7 @@ namespace Microsoft.Extensions.Localization.Tests
             {
                 var client = server.CreateClient();
                 var culture = new CultureInfo("ar-SA");
-                var requestCulture = new RequestCulture(culture);
+                var requestCulture = new RequestCulture(culture, TimeZoneInfo.Local);
                 var value = CookieRequestCultureProvider.MakeCookieValue(requestCulture);
                 client.DefaultRequestHeaders.Add("Cookie", new CookieHeaderValue("Preferences", value).ToString());
                 var response = await client.GetAsync(string.Empty);
@@ -66,7 +67,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA")
@@ -104,7 +105,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA")

--- a/test/Microsoft.AspNet.Localization.Tests/CustomRequestCultureProviderTest.cs
+++ b/test/Microsoft.AspNet.Localization.Tests/CustomRequestCultureProviderTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar")

--- a/test/Microsoft.AspNet.Localization.Tests/QueryStringRequestCultureProviderTest.cs
+++ b/test/Microsoft.AspNet.Localization.Tests/QueryStringRequestCultureProviderTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNet.Http.Features;
 using Microsoft.AspNet.Localization;
 using Microsoft.AspNet.TestHost;
 using Xunit;
+using System;
 
 namespace Microsoft.Extensions.Localization.Tests
 {
@@ -23,7 +24,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA")
@@ -58,7 +59,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                     });
                     app.Run(context =>
                     {
@@ -85,7 +86,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA")
@@ -119,7 +120,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA")
@@ -153,7 +154,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA")
@@ -188,7 +189,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA")
@@ -223,7 +224,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("ar-SA")
@@ -262,7 +263,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 {
                     app.UseRequestLocalization(options =>
                     {
-                        options.DefaultRequestCulture = new RequestCulture("en-US");
+                        options.DefaultRequestCulture = new RequestCulture("en-US", TimeZoneInfo.Local.Id);
                         options.SupportedCultures = new List<CultureInfo>
                         {
                             new CultureInfo("FR")


### PR DESCRIPTION
I don't expect this PR to be accepted, but hope it will start a talk about how we get the TimeZone information into the request somehow.

I understand this can not be solved in aspnet5, but any change needs to be put into the main .NET framework too.

It would be nice with a simpler solution to handle time zones properly in web applications, in the generated output. When storing dates in databases as UTC, and with authenticated users where you know their time zone, it would be sweet if ToShortTime and other methods used for outputting times would "just work", like they do for dates and the threads CultureInfo setting.