### PR TITLE
Localization Sample Fix

### DIFF
--- a/samples/LocalizationSample/Startup.cs
+++ b/samples/LocalizationSample/Startup.cs
@@ -36,21 +36,19 @@ namespace LocalizationSample
 #if !DNXCORE50
             supportedCultures.Add(new CultureInfo("zh-CHT"));
 #endif
-            app.UseRequestLocalization(new RequestLocalizationOptions
-            {
+            var options = new RequestLocalizationOptions {
                 DefaultRequestCulture = new RequestCulture("en-US"),
-
-                // Set options here to change middleware behavior
                 SupportedCultures = supportedCultures,
                 SupportedUICultures = supportedCultures
+            };
+            // Optionally create an app-specific provider with just a delegate, e.g. look up user preference from DB.
+            // Inserting it as position 0 ensures it has priority over any of the default providers.
+            //options.RequestCultureProviders.Insert(0, new CustomRequestCultureProvider(async context =>
+            //{
 
-                // Optionally create an app-specific provider with just a delegate, e.g. look up user preference from DB.
-                // Inserting it as position 0 ensures it has priority over any of the default providers.
-                //RequestCultureProviders.Insert(0, new CustomRequestCultureProvider(async context =>
-                //{
+            //}));
 
-                //}))
-            });
+            app.UseRequestLocalization(options);
 
             app.Use(async (context, next) =>
             {


### PR DESCRIPTION
After option pattern has been applied to localization repo, seems you can't use ```RequestCultureProviders.Insert``` inside ```UseRequestLocalization``` because ```RequestCultureProviders``` will get its value during the instantiation process. While the [line](https://github.com/aspnet/Localization/blob/dev/samples/LocalizationSample/Startup.cs#L49) is commented perhaps no one notice that you can't invoke ```Insert``` method anymore
/cc @Eilon 