### PR TITLE
Resolve test application paths more robustly

### DIFF
--- a/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationSampleTest.cs
+++ b/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationSampleTest.cs
@@ -12,8 +12,7 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
 {
     public class LocalizationSampleTest
     {
-        private static readonly string _applicationPath = Path.GetFullPath(
-            Path.Combine(PlatformServices.Default.Application.ApplicationBasePath, "..", "..", "..", "..", "..", "..", "samples", "LocalizationSample"));
+        private static readonly string _applicationPath =  Path.Combine("samples", "LocalizationSample");
 
         [ConditionalTheory]
         [OSSkipCondition(OperatingSystems.Linux)]

--- a/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationTest.cs
+++ b/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationTest.cs
@@ -12,8 +12,7 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
 {
     public class LocalizationTest
     {
-        private static readonly string _applicationPath = Path.GetFullPath(
-            Path.Combine(PlatformServices.Default.Application.ApplicationBasePath, "..", "..", "..", "..", "..", "LocalizationWebsite"));
+        private static readonly string _applicationPath = Path.Combine("test", "LocalizationWebsite");
         
         [ConditionalTheory]
         [OSSkipCondition(OperatingSystems.Linux)]


### PR DESCRIPTION
This will fix the full framework tests launched on Mono. The relative paths were broken since we disable app domains and need to resolve paths from xunit.runner.exe. Resolving from the repo root folder is more robust.

cc @pranavkm @BrennanConroy 