### PR TITLE
Use existing CultureInfo

### DIFF
--- a/src/Microsoft.Extensions.Globalization.CultureInfoCache/CultureInfoCache.cs
+++ b/src/Microsoft.Extensions.Globalization.CultureInfoCache/CultureInfoCache.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.Globalization
     /// <summary>
     /// Provides read-only cached instances of <see cref="CultureInfo"/>.
     /// </summary>
+    [Obsolete("This type is obsolete and will be removed in a future version.")]
     public static class CultureInfoCache
     {
         private static readonly ConcurrentDictionary<string, CacheEntry> _cache = new ConcurrentDictionary<string, CacheEntry>();
@@ -23,7 +24,7 @@ namespace Microsoft.Extensions.Globalization
         /// <param name="name">The culture name.</param>
         /// <param name="supportedCultures">The cultures supported by the application.</param>
         /// <returns>
-        /// A read-only cached <see cref="CultureInfo"/> or <c>null</c> a match wasn't found in
+        /// A read-only cached <see cref="CultureInfo"/> or <c>null</c> if a match wasn't found in
         /// <paramref name="supportedCultures"/>.
         /// </returns>
         public static CultureInfo GetCultureInfo(string name, IList<CultureInfo> supportedCultures)

--- a/test/LocalizationWebsite/StartupCustomCulturePreserved.cs
+++ b/test/LocalizationWebsite/StartupCustomCulturePreserved.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LocalizationWebsite
+{
+    public class StartupCustomCulturePreserved
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddLocalization();
+        }
+
+        public void Configure(
+            IApplicationBuilder app)
+        {
+            app.UseRequestLocalization(new RequestLocalizationOptions
+            {
+                DefaultRequestCulture = new RequestCulture("en-US"),
+                SupportedCultures = new List<CultureInfo>()
+                {
+                    new CultureInfo("en-US") { NumberFormat= { CurrencySymbol = "kr" } }
+                },
+                SupportedUICultures = new List<CultureInfo>()
+                {
+                    new CultureInfo("en-US") { NumberFormat= { CurrencySymbol = "kr" } }
+                }
+            });
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync(10.ToString("C"));
+            });
+        }
+    }
+}

--- a/test/LocalizationWebsite/project.json
+++ b/test/LocalizationWebsite/project.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.Localization": "1.1.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.1.0-*",
+    "Microsoft.AspNetCore.Testing": "1.1.0-*",
     "Microsoft.Extensions.Configuration.CommandLine": "1.1.0-*",
     "Microsoft.Extensions.Localization": "1.1.0-*",
     "Microsoft.Extensions.Logging.Console": "1.1.0-*",

--- a/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationTest.cs
+++ b/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationTest.cs
@@ -13,6 +13,19 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
     {
         private static readonly string _applicationPath = Path.Combine("test", "LocalizationWebsite");
 
+        [Fact]
+        public Task Localization_CustomCulture()
+        {
+            var testRunner = new TestRunner(_applicationPath);
+            return testRunner.RunTestAndVerifyResponse(
+                RuntimeFlavor.CoreClr,
+                RuntimeArchitecture.x64,
+                "http://localhost:5070",
+                "CustomCulturePreserved",
+                "en-US",
+                "kr10.00");
+        }
+
         [ConditionalTheory]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]


### PR DESCRIPTION
Fixes #203. Given this fix `CultureInfoCache` could just as a easily be a helper function on the middleware since it's no longer an actual cache, but I wasn't sure if we would be able to get rid of the whole class like that. @DamianEdwards would that be possible?