### PR TITLE
Remove unnecessary code in ResourceManagerStringLocalizer

### DIFF
--- a/src/Microsoft.Extensions.Localization/ResourceManagerStringLocalizer.cs
+++ b/src/Microsoft.Extensions.Localization/ResourceManagerStringLocalizer.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Extensions.Localization
         private readonly IResourceNamesCache _resourceNamesCache;
         private readonly ResourceManager _resourceManager;
         private readonly IResourceStringProvider _resourceStringProvider;
-        private readonly AssemblyWrapper _resourceAssemblyWrapper;
         private readonly string _resourceBaseName;
 
         /// <summary>
@@ -43,10 +42,6 @@ namespace Microsoft.Extensions.Localization
                 baseName,
                 resourceNamesCache)
         {
-            if (resourceAssembly == null)
-            {
-                throw new ArgumentNullException(nameof(resourceAssembly));
-            }
         }
 
         /// <summary>
@@ -63,7 +58,6 @@ namespace Microsoft.Extensions.Localization
                   baseName,
                   resourceNamesCache)
         {
-            _resourceAssemblyWrapper = resourceAssemblyWrapper;
         }
 
         /// <summary>


### PR DESCRIPTION
After the PR #299 I notice there's some unnecessary lines of code, also there's an extra check from awhile [here](https://github.com/aspnet/Localization/blob/dev/src/Microsoft.Extensions.Localization/ResourceManagerStringLocalizer.cs#L48) because the `AssemblyWrapper` is already perform this check

/cc @Eilon @ryanbrandenburg 