### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/samples/LocalizationSample/LocalizationSample.csproj
+++ b/samples/LocalizationSample/LocalizationSample.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <!-- TODO remove when https://github.com/dotnet/sdk/issues/396 is resolved -->
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>

--- a/test/LocalizationWebsite/LocalizationWebsite.csproj
+++ b/test/LocalizationWebsite/LocalizationWebsite.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <!-- TODO remove when https://github.com/dotnet/sdk/issues/396 is resolved -->
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>

--- a/test/Microsoft.AspNetCore.Localization.FunctionalTests/TestRunner.cs
+++ b/test/Microsoft.AspNetCore.Localization.FunctionalTests/TestRunner.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
                 {
                     ApplicationBaseUriHint = applicationBaseUrl,
                     EnvironmentName = environmentName,
-                    TargetFramework = runtimeFlavor == RuntimeFlavor.Clr ? "net451" : "netcoreapp1.1"
+                    TargetFramework = runtimeFlavor == RuntimeFlavor.Clr ? "net452" : "netcoreapp1.1"
                 };
 
                 using (var deployer = ApplicationDeployerFactory.Create(deploymentParameters, logger))

--- a/test/Microsoft.AspNetCore.Localization.Routing.Tests/Microsoft.AspNetCore.Localization.Routing.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Localization.Routing.Tests/Microsoft.AspNetCore.Localization.Routing.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Localization.Tests/Microsoft.AspNetCore.Localization.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Localization.Tests/Microsoft.AspNetCore.Localization.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Localization.Tests/RequestLocalizationOptionsTest.cs
+++ b/test/Microsoft.AspNetCore.Localization.Tests/RequestLocalizationOptionsTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Localization.Tests
         {
             // Arrange
             var explicitCulture = new CultureInfo("fr-FR");
-#if NET451
+#if NET452
             Thread.CurrentThread.CurrentCulture = explicitCulture;
             Thread.CurrentThread.CurrentUICulture = explicitCulture;
 #else
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Localization.Tests
         {
             // Arrange
             var explicitCulture = new CultureInfo("fr-FR");
-#if NET451
+#if NET452
             Thread.CurrentThread.CurrentCulture = explicitCulture;
             Thread.CurrentThread.CurrentUICulture = explicitCulture;
 #else
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Localization.Tests
 
         public void Dispose()
         {
-#if NET451
+#if NET452
             Thread.CurrentThread.CurrentCulture = _initialCulture;
             Thread.CurrentThread.CurrentUICulture = _initialUICulture;
 #else

--- a/test/Microsoft.Extensions.Localization.Tests/Microsoft.Extensions.Localization.Tests.csproj
+++ b/test/Microsoft.Extensions.Localization.Tests/Microsoft.Extensions.Localization.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ResourcesClassLibraryNoAttribute/ResourcesClassLibraryNoAttribute.csproj
+++ b/test/ResourcesClassLibraryNoAttribute/ResourcesClassLibraryNoAttribute.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.6</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/test/ResourcesClassLibraryWithAttribute/ResourcesClassLibraryWithAttribute.csproj
+++ b/test/ResourcesClassLibraryWithAttribute/ResourcesClassLibraryWithAttribute.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.6</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows