### PR TITLE
Remove RuntimeIdentifier from web projects

### DIFF
--- a/samples/LocalizationSample/LocalizationSample.csproj
+++ b/samples/LocalizationSample/LocalizationSample.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
-    <!-- TODO remove when https://github.com/dotnet/sdk/issues/396 is resolved -->
-    <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/test/LocalizationWebsite/LocalizationWebsite.csproj
+++ b/test/LocalizationWebsite/LocalizationWebsite.csproj
@@ -5,8 +5,6 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
-    <!-- TODO remove when https://github.com/dotnet/sdk/issues/396 is resolved -->
-    <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
The runtime Ids should be removed from .csproj web projects while https://github.com/dotnet/sdk/issues/396 is got fixed