### PR TITLE
Automatically allocate ports for functional tests

### DIFF
--- a/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationSampleTest.cs
+++ b/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationSampleTest.cs
@@ -23,7 +23,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponseHeading(
                 RuntimeFlavor.Clr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5080",
                 "My/Resources",
                 "fr-FR",
                 "<h1>Bonjour</h1>");
@@ -37,7 +36,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponseHeading(
                 RuntimeFlavor.CoreClr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5081/",
                 "My/Resources",
                 "fr-FR",
                 "<h1>Bonjour</h1>");

--- a/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationTest.cs
+++ b/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationTest.cs
@@ -21,7 +21,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.CoreClr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5070",
                 "CustomCulturePreserved",
                 "en-US",
                 "kr10.00");
@@ -37,7 +36,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.Clr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5071",
                 "CustomCulturePreserved",
                 "en-US",
                 "kr10.00");
@@ -51,7 +49,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.CoreClr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5072",
                 "ResourcesInClassLibrary",
                 "fr-FR",
                 "Bonjour from ResourcesClassLibraryNoAttribute Bonjour from ResourcesClassLibraryNoAttribute Bonjour from ResourcesClassLibraryWithAttribute Bonjour from ResourcesClassLibraryWithAttribute");
@@ -67,7 +64,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.Clr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5073",
                 "ResourcesInClassLibrary",
                 "fr-FR",
                 "Bonjour from ResourcesClassLibraryNoAttribute Bonjour from ResourcesClassLibraryNoAttribute Bonjour from ResourcesClassLibraryWithAttribute Bonjour from ResourcesClassLibraryWithAttribute");
@@ -81,7 +77,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.CoreClr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5074",
                 "ResourcesInFolder",
                 "fr-FR",
                 "Bonjour from StartupResourcesInFolder Bonjour from Test in resources folder Bonjour from Customer in resources folder Hello");
@@ -97,7 +92,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.Clr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5075/",
                 "ResourcesInFolder",
                 "fr-FR",
                 "Bonjour from StartupResourcesInFolder Bonjour from Test in resources folder Bonjour from Customer in resources folder Hello");
@@ -111,7 +105,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.CoreClr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5076",
                 "ResourcesInFolder",
                 "fr-FR-test",
                 "Bonjour from StartupResourcesInFolder Bonjour from Test in resources folder Bonjour from Customer in resources folder Hello");
@@ -127,7 +120,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.Clr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5077",
                 "ResourcesInFolder",
                 "fr-FR-test",
                 "Bonjour from StartupResourcesInFolder Bonjour from Test in resources folder Bonjour from Customer in resources folder Hello");
@@ -141,7 +133,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.CoreClr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5078/",
                 "ResourcesInFolder",
                 "fr-FR-test-again-too-deep-to-work",
                 "Hello Hello Hello Hello");
@@ -157,7 +148,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.Clr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5079/",
                 "ResourcesInFolder",
                 "fr-FR-test-again-too-deep-to-work",
                 "Hello Hello Hello Hello");
@@ -171,7 +161,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.CoreClr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5070",
                 "ResourcesAtRootFolder",
                 "fr-FR",
                 "Bonjour from StartupResourcesAtRootFolder Bonjour from Test in root folder Bonjour from Customer in Models folder");
@@ -187,7 +176,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
             return testRunner.RunTestAndVerifyResponse(
                 RuntimeFlavor.Clr,
                 RuntimeArchitecture.x64,
-                "http://localhost:5071",
                 "ResourcesAtRootFolder",
                 "fr-FR",
                 "Bonjour from StartupResourcesAtRootFolder Bonjour from Test in root folder Bonjour from Customer in Models folder");

--- a/test/Microsoft.AspNetCore.Localization.FunctionalTests/TestRunner.cs
+++ b/test/Microsoft.AspNetCore.Localization.FunctionalTests/TestRunner.cs
@@ -14,6 +14,8 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
 {
     public class TestRunner
     {
+        private const string ApplicationBasePath = "http://localhost:0";
+
         private string _applicationPath;
 
         public TestRunner(string applicationPath)
@@ -44,7 +46,6 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
         private async Task<string> RunTestAndGetResponse(
             RuntimeFlavor runtimeFlavor,
             RuntimeArchitecture runtimeArchitecture,
-            string applicationBaseUrl,
             string environmentName,
             string locale)
         {
@@ -52,7 +53,7 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
 
             var deploymentParameters = new DeploymentParameters(_applicationPath, ServerType.Kestrel, runtimeFlavor, runtimeArchitecture)
             {
-                ApplicationBaseUriHint = applicationBaseUrl,
+                ApplicationBaseUriHint = ApplicationBasePath,
                 EnvironmentName = environmentName,
                 TargetFramework = runtimeFlavor == RuntimeFlavor.Clr ? "net46" : "netcoreapp2.0"
             };
@@ -86,12 +87,11 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
         public async Task RunTestAndVerifyResponse(
             RuntimeFlavor runtimeFlavor,
             RuntimeArchitecture runtimeArchitecture,
-            string applicationBaseUrl,
             string environmentName,
             string locale,
             string expectedText)
         {
-            var responseText = await RunTestAndGetResponse(runtimeFlavor, runtimeArchitecture, applicationBaseUrl, environmentName, locale);
+            var responseText = await RunTestAndGetResponse(runtimeFlavor, runtimeArchitecture, environmentName, locale);
             Console.WriteLine("Response Text " + responseText);
             Assert.Equal(expectedText, responseText);
         }
@@ -99,12 +99,11 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
         public async Task RunTestAndVerifyResponseHeading(
             RuntimeFlavor runtimeFlavor,
             RuntimeArchitecture runtimeArchitecture,
-            string applicationBaseUrl,
             string environmentName,
             string locale,
             string expectedHeadingText)
         {
-            var responseText = await RunTestAndGetResponse(runtimeFlavor, runtimeArchitecture, applicationBaseUrl, environmentName, locale);
+            var responseText = await RunTestAndGetResponse(runtimeFlavor, runtimeArchitecture, environmentName, locale);
             var headingIndex = responseText.IndexOf(expectedHeadingText);
             Console.WriteLine("Response Header " + responseText);
             Assert.True(headingIndex >= 0);


### PR DESCRIPTION
Fixes #358. This is the same thing we do [here](https://github.com/aspnet/Performance/blob/fa204e1b1878b2214a1f34bee29d0f00af41186a/src/Benchmarks.Utility/Helpers/IISTestManager.cs#L44).