### PR TITLE
Change culture fallback to use corefx parent culture

### DIFF
--- a/test/LocalizationWebsite/StartupChineseLocaleFallback.cs
+++ b/test/LocalizationWebsite/StartupChineseLocaleFallback.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using LocalizationWebsite.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+
+namespace LocalizationWebsite
+{
+    public class StartupChineseLocaleFallback
+    {
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseRequestLocalization(new RequestLocalizationOptions
+            {
+                DefaultRequestCulture = new RequestCulture("en-US"),
+                SupportedCultures = new List<CultureInfo>()
+                {
+                    new CultureInfo("zh-Hans")
+                }
+            });
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync(CultureInfo.CurrentCulture.Name);
+            });
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationTest.cs
+++ b/test/Microsoft.AspNetCore.Localization.FunctionalTests/LocalizationTest.cs
@@ -77,6 +77,15 @@ namespace Microsoft.AspNetCore.Localization.FunctionalTests
                 "Bonjour from StartupResourcesAtRootFolder Bonjour from Test in root folder Bonjour from Customer in Models folder");
         }
 
+        [Fact]
+        public Task Localization_FallbackToParentLocale()
+        {
+            return RunTest(
+                typeof(StartupChineseLocaleFallback),
+                "zh-CN",
+                "zh-Hans");
+        }
+
         private async Task RunTest(Type startupType, string culture, string expected)
         {
             var webHostBuilder = new WebHostBuilder().UseStartup(startupType);


### PR DESCRIPTION
Uses `CultureInfo.Parent` as fallback parent culture, instead of trimming last part.

Resolves https://github.com/aspnet/Localization/issues/273 and https://github.com/aspnet/Localization/issues/415

@hishamco @ryanbrandenburg