### PR TITLE
Allow setting RootNamespace in ResourceLocationAttribute

### DIFF
--- a/src/Microsoft.Extensions.Localization/RootNamespaceAttribute.cs
+++ b/src/Microsoft.Extensions.Localization/RootNamespaceAttribute.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Localization
+{
+    /// <summary>
+    /// Provides the RootNamespace of an Assembly. The RootNamespace of the assembly is used by Localization to
+    /// determine the resource name to look for when RootNamespace differs from the AssemblyName.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+    public class RootNamespaceAttribute : Attribute
+    {
+        /// <summary>
+        /// Creates a new <see cref="RootNamespaceAttribute"/>.
+        /// </summary>
+        /// <param name="rootNamespace">The RootNamespace for this Assembly.</param>
+        public RootNamespaceAttribute(string rootNamespace)
+        {
+            if (string.IsNullOrEmpty(rootNamespace))
+            {
+                throw new ArgumentNullException(nameof(rootNamespace));
+            }
+
+            RootNamespace = rootNamespace;
+        }
+
+        /// <summary>
+        /// The RootNamespace of this Assembly. The RootNamespace of the assembly is used by Localization to
+        /// determine the resource name to look for when RootNamespace differs from the AssemblyName.
+        /// </summary>
+        public string RootNamespace { get; }
+    }
+}

--- a/test/ResourcesClassLibraryWithAttribute/AssemblyInfo.cs
+++ b/test/ResourcesClassLibraryWithAttribute/AssemblyInfo.cs
@@ -5,3 +5,4 @@ using System.Reflection;
 using Microsoft.Extensions.Localization;
 
 [assembly: ResourceLocation("ResourceFolder")]
+[assembly: RootNamespace("Alternate.Namespace")]

--- a/test/ResourcesClassLibraryWithAttribute/ResourcesClassLibraryWithAttribute.csproj
+++ b/test/ResourcesClassLibraryWithAttribute/ResourcesClassLibraryWithAttribute.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Alternate.Namespace</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes the problem of us lacking a RootNamespace at runtime. I've made it a separate attribute so that when we create it using a task in the future people won't have to worry about the task interfeering with their `ResourceLocationAttribute`.